### PR TITLE
Rayonix pixel size

### DIFF
--- a/src/PyDetectorAccess.py
+++ b/src/PyDetectorAccess.py
@@ -463,7 +463,7 @@ class PyDetectorAccess(object):
 
 
     def pixel_size(self, par):
-        #if self.dettype == gu.RAYONIX: return self.pixel_size_rayonix()
+        if self.dettype == gu.RAYONIX: return self.pixel_size_rayonix()
         if self.geoaccess(par) is None: return None
         else:
             if  self.pixel_size_val is None:


### PR DESCRIPTION
It was noticed during mfxlx5520 that the Rayonix always reports a pixel width of 89um while it should report a number proportional to 44um, with a factor equal to the bin size set in the DAQ. For mfxlx5520, the binning is 4x4 so the pixel width should be 176um.

The impact on analysis is an incorrect estimation of the detector distance and thus the coffset. It should not matter assuming all processing does the same "scaling" of the pixel width and detector distance consistently, but it would be preferable to retrieve the actual pixel width for any binning setting of the Rayonix.
We have checked that manually doing what `pixel_size_rayonix()` does fixed the issue.
It seems that in earlier version of `Detector`, this behavior was enforced, but has been disabled since.

Any reason why we should leave this line commented out, or should uncomment it?